### PR TITLE
Build(deps): Bump poetry from 1.8 to 2.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        python-ver: ['3.12', '3.11', '3.10', '3.9']
+        python-ver: ['3.13', '3.12', '3.11', '3.10']
     
     steps:
       - name: Check out repo  # for deps, source code and package build config

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-ver: ['3.12', '3.11', '3.10', '3.9']
+        python-ver: ['3.13', '3.12', '3.11', '3.10']
 
     steps:
       - name: Check out repo  # for deps, source code and unit tests

--- a/Makefile
+++ b/Makefile
@@ -31,29 +31,30 @@ PKG_VER := 0.1.0
 # virtual env, install packages, and/or install pre-commit hooks.
 setup: $(VENV_DIR)/bin/activate $(VENV_DIR)/bin/pre-commit
 
-update: setup pip-install pre-commit-install
+update: setup uv-install pre-commit-install
 
 $(VENV_DIR)/bin/activate:
 	@$(MAKE) clean
 	@echo "Setting up development environment using $(PYTHON3)..."
 	$(PYTHON3) -m venv $(VENV_DIR) --upgrade-deps
-	@$(MAKE) pip-install
+	@$(MAKE) uv-install
 	@$(MAKE) pre-commit-install
 	@echo "Development environment setup complete."
 
 $(VENV_DIR)/bin/pre-commit:
-	@$(MAKE) pip-install
+	@$(MAKE) uv-install
 	@$(MAKE) pre-commit-install
 
-pip-install:
-	@echo "Upgrading pip..."
+uv-install:
+	@echo "Upgrading uv..."
 	$(VENV_DIR)/bin/pip install --upgrade pip
+	$(VENV_DIR)/bin/pip install --upgrade uv
 	@echo "Installing required Python packages..."
 	@find $(PROJ_ROOT_DIR) \
 		-path '*/.aws-sam' -prune -o \
 		-path '*/lambda_layer' -prune -o \
 		-name 'requirements.txt' -print0 | \
-		xargs -0 -I {} $(VENV_DIR)/bin/pip install -r {}
+		xargs -0 -I {} $(VENV_DIR)/bin/uv pip install -r {}
 
 pre-commit-install:
 	@echo "Installing pre-commit hooks..."

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Poll a target function for status.
 | | |
 | --- | --- |
 | Testing | [![CI - Test](https://github.com/topshelfsoftware/python-polling/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/topshelfsoftware/python-polling/actions/workflows/unit-tests.yaml) [![codecov](https://codecov.io/gh/topshelfsoftware/python-polling/graph/badge.svg?token=YGAMALL0YD)](https://codecov.io/gh/topshelfsoftware/python-polling) |
-| Package | [![Build Status](https://github.com/topshelfsoftware/python-polling/actions/workflows/build.yaml/badge.svg)](https://github.com/topshelfsoftware/python-polling/actions/workflows/build.yaml) ![Package Version](https://img.shields.io/badge/latest-v0.1.0-blue) ![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12-blue?logo=python&logoColor=yellow) |
+| Package | [![Build Status](https://github.com/topshelfsoftware/python-polling/actions/workflows/build.yaml/badge.svg)](https://github.com/topshelfsoftware/python-polling/actions/workflows/build.yaml) ![Package Version](https://img.shields.io/badge/latest-v0.1.0-blue) ![Python Versions](https://img.shields.io/badge/python-3.10_%7C_3.11_%7C_3.12_%7C_3.13-blue?logo=python&logoColor=yellow) |
 | Meta | [![License](https://img.shields.io/github/license/topshelfsoftware/python-polling)](https://github.com/topshelfsoftware/python-polling/blob/main/LICENSE) |
 
 ## Getting Started
 
 ### Prerequisites
 
-1. Python 3.9 | 3.10 | 3.11 | 3.12 installed on system
+1. Python 3.10 | 3.11 | 3.12 | 3.13 installed on system
 2. `aws-sam-cli` with "sam" on system path
 3. Optionally, create a file named `local_pypi_dir.txt` in the project root directory (same folder as this `README`)
     - Contents of file are a single line defining the path to a local directory to be used as a local PyPI repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "./docs/README.md"
 repository = "https://github.com/topshelfsoftware/python-polling"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 topshelfsoftware_logging = { git = "https://github.com/topshelfsoftware/python-logging.git", tag = "v1.0.0" }
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 topshelfsoftware-logging @ git+https://github.com/topshelfsoftware/python-logging.git@v1.0.0
 
 # dev tools
-poetry~=1.8
+poetry~=2.4
 pre-commit~=3.7
 black>=24.4
-ruff>=0.5
+ruff>=0.5,<0.16

--- a/template.yaml
+++ b/template.yaml
@@ -27,10 +27,10 @@ Resources:
       Description: !Ref PackageVersion
       ContentUri: lambda_layer/
       CompatibleRuntimes:
-        - python3.9
         - python3.10
         - python3.11
         - python3.12
+        - python3.13
       LicenseInfo: MIT
       RetentionPolicy: Retain
   

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 --trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org
-pytest~=8.0
+pytest~=9.1
 pytest-cov~=5.0
 pyyaml~=6.0


### PR DESCRIPTION
Addresses the following CVE:
- `poetry`: CVE-2026-34591
- `pytest`: CVE-2025-71176

Additionally, replace `pip` with `uv` for performant package management